### PR TITLE
Improve Gitpod setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,7 @@
 image: gitpod/workspace-full-vnc
 ports:
+  - port: 5555
+    onOpen: ignore
   - port: 5900
     onOpen: ignore
   - port: 6080
@@ -7,4 +9,7 @@ ports:
 tasks:
   - init: pip3 install -r requirements.txt
     command: python3 server.py
-  - command: python3 game.py
+    name: Server
+  - command: gp await-port 5555 && python3 game.py
+    openMode: split-right
+    name: Client


### PR DESCRIPTION
Hey @techwithtim!

It's super cool that you've made an online chess game, thanks for that! 😄 I noticed that the Gitpod setup is a bit broken, so I wanted to try and fix it, but I may need your help.

In this PR, I've:
- named the two terminals `Server` and `Client`, and opened them side-by-side (split terminals)
- made the Client wait for port `5555` to become active (to wait for dependencies to be installed and for the Server to start)
- ignored port `5555`, so that it doesn't show a notification

I now get this result:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/Online-Chess-Game)
<img width="1552" alt="Screenshot 2019-07-02 at 18 13 37" src="https://user-images.githubusercontent.com/599268/60528639-24cf5980-9cf5-11e9-9f0b-e6c2a3187590.png">
However, even when I enter my name into the Client ("Jan"), nothing happens: no graphical window opens, no error is logged...

If you have time, please help me troubleshoot this. I'd love to help get it to work. 😊